### PR TITLE
Fix parse.split() to handle paths correctly

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -41,7 +41,7 @@ exports.split = function(string) {
   if (string == null) {
     return [];
   }
-  return string.match(/[\w-\*]+|[<\[][^<\[]+[>\]]/g) || [];
+  return string.match(/[\w-\*/\\:\.~]+|[<\[][^<\[]+[>\]]/g) || [];
 };
 
 exports.parseOptions = function(definedOptions, options) {

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -33,7 +33,10 @@ exports.parse = (argv) ->
 
 exports.split = (string) ->
 	return [] if not string?
-	return string.match(/[\w-\*]+|[<\[][^<\[]+[>\]]/g) or []
+
+	# TODO: This regex should be vastly improved to avoid
+	# having to type all special characters manually
+	return string.match(/[\w-\*/\\:\.~]+|[<\[][^<\[]+[>\]]/g) or []
 
 exports.parseOptions = (definedOptions, options = {}) ->
 	result = {}

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -184,6 +184,26 @@ describe 'Parse:', ->
 			result = [ '[hello world...]', '[foo bar baz...]' ]
 			expect(parse.split(signature)).to.deep.equal(result)
 
+		it 'should split absolute paths parameters correctly', ->
+			signature = 'foo /Users/me/foo/bar'
+			result = [ 'foo', '/Users/me/foo/bar' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
+		it 'should split absolute paths (win32) parameters correctly', ->
+			signature = 'foo C:\\Users\\me\\foo\\bar'
+			result = [ 'foo', 'C:\\Users\\me\\foo\\bar' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
+		it 'should split relative paths parameters correctly', ->
+			signature = 'foo ../hello/world'
+			result = [ 'foo', '../hello/world' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
+		it 'should split home relative paths parameters correctly', ->
+			signature = 'foo ~/.ssh/id_rsa.pub'
+			result = [ 'foo', '~/.ssh/id_rsa.pub' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
 	describe '#parseOptions()', ->
 
 		it 'should not throw if options is undefined', ->

--- a/tests/signature.spec.coffee
+++ b/tests/signature.spec.coffee
@@ -381,3 +381,23 @@ describe 'Signature:', ->
 				result = signature.compileParameters('foo 19')
 				expect(result).to.deep.equal
 					bar: 19
+
+		describe 'given path commands', ->
+
+			it 'should be able to parse absolute paths', ->
+				signature = new Signature('foo <bar>')
+				result = signature.compileParameters('foo /Users/me/foo/bar')
+				expect(result).to.deep.equal
+					bar: '/Users/me/foo/bar'
+
+			it 'should be able to parse relative paths', ->
+				signature = new Signature('foo <bar>')
+				result = signature.compileParameters('foo ../hello/world')
+				expect(result).to.deep.equal
+					bar: '../hello/world'
+
+			it 'should be able to parse home relative paths', ->
+				signature = new Signature('foo <bar>')
+				result = signature.compileParameters('foo ~/.ssh/id_rsa.pub')
+				expect(result).to.deep.equal
+					bar: '~/.ssh/id_rsa.pub'


### PR DESCRIPTION
`parse.split()` currently gives incorrect results when splitting strings containing paths (both UNIX and Win32).
