### PR TITLE
Fix parse.split() not splitting quoted strings correctly

### DIFF
--- a/build/parameter.js
+++ b/build/parameter.js
@@ -78,12 +78,7 @@ module.exports = Parameter = (function() {
       }
     } else {
       if (this.isRequired()) {
-        if (parameterWordsLength !== 1) {
-          return false;
-        }
-      }
-      if (this.isOptional()) {
-        if (parameterWordsLength > 1) {
+        if (parameterWordsLength < 1) {
           return false;
         }
       }

--- a/build/parse.js
+++ b/build/parse.js
@@ -38,10 +38,16 @@ exports.parse = function(argv) {
 };
 
 exports.split = function(string) {
+  var result;
   if (string == null) {
     return [];
   }
-  return string.match(/[\w-\*/\\:\.~]+|[<\[][^<\[]+[>\]]/g) || [];
+  result = string.match(/[\w-\*/\\:\.~]+|[<\['"][^<\[]+[>\]'"]/g) || [];
+  return _.map(result, function(word) {
+    word = _.str.unquote(word, '\'');
+    word = _.str.unquote(word, '"');
+    return word;
+  });
 };
 
 exports.parseOptions = function(definedOptions, options) {

--- a/lib/parameter.coffee
+++ b/lib/parameter.coffee
@@ -52,10 +52,7 @@ module.exports = class Parameter
 			return false if parameterWordsLength < 1
 		else
 			if @isRequired()
-				return false if parameterWordsLength isnt 1
-
-			if @isOptional()
-				return false if parameterWordsLength > 1
+				return false if parameterWordsLength < 1
 
 		return true
 

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -36,7 +36,11 @@ exports.split = (string) ->
 
 	# TODO: This regex should be vastly improved to avoid
 	# having to type all special characters manually
-	return string.match(/[\w-\*/\\:\.~]+|[<\[][^<\[]+[>\]]/g) or []
+	result = string.match(/[\w-\*/\\:\.~]+|[<\['"][^<\[]+[>\]'"]/g) or []
+	return _.map result, (word) ->
+		word = _.str.unquote(word, '\'')
+		word = _.str.unquote(word, '"')
+		return word
 
 exports.parseOptions = (definedOptions, options = {}) ->
 	result = {}

--- a/tests/parameter.spec.coffee
+++ b/tests/parameter.spec.coffee
@@ -257,8 +257,8 @@ describe 'Parameter:', ->
 			it 'should return true if it matches', ->
 				expect(@parameter.matches('bar')).to.be.true
 
-			it 'should return false if command exceeds', ->
-				expect(@parameter.matches('bar baz')).to.be.false
+			it 'should return true if command exceeds', ->
+				expect(@parameter.matches('bar baz')).to.be.true
 
 		describe 'given an optional parameter', ->
 
@@ -272,8 +272,8 @@ describe 'Parameter:', ->
 			it 'should return true if it matches', ->
 				expect(@parameter.matches('hello')).to.be.true
 
-			it 'should return false if it exceeds', ->
-				expect(@parameter.matches('hello world')).to.be.false
+			it 'should return true if it exceeds', ->
+				expect(@parameter.matches('hello world')).to.be.true
 
 		describe 'given a required variadic parameter', ->
 

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -204,6 +204,16 @@ describe 'Parse:', ->
 			result = [ 'foo', '~/.ssh/id_rsa.pub' ]
 			expect(parse.split(signature)).to.deep.equal(result)
 
+		it 'should split words surrounded by quotes correctly', ->
+			signature = 'foo \'hello world\''
+			result = [ 'foo', 'hello world' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
+		it 'should split words surrounded by double quotes correctly', ->
+			signature = 'foo "hello world"'
+			result = [ 'foo', 'hello world' ]
+			expect(parse.split(signature)).to.deep.equal(result)
+
 	describe '#parseOptions()', ->
 
 		it 'should not throw if options is undefined', ->

--- a/tests/signature.spec.coffee
+++ b/tests/signature.spec.coffee
@@ -401,3 +401,17 @@ describe 'Signature:', ->
 				result = signature.compileParameters('foo ~/.ssh/id_rsa.pub')
 				expect(result).to.deep.equal
 					bar: '~/.ssh/id_rsa.pub'
+
+		describe 'given quoted multi word command words', ->
+
+			it 'should parse single quoted multi words correctly', ->
+				signature = new Signature('foo <bar>')
+				result = signature.compileParameters('foo \'hello world\'')
+				expect(result).to.deep.equal
+					bar: 'hello world'
+
+			it 'should parse double quoted multi words correctly', ->
+				signature = new Signature('foo <bar>')
+				result = signature.compileParameters('foo "hello world"')
+				expect(result).to.deep.equal
+					bar: 'hello world'


### PR DESCRIPTION
`parse.split()` currently gives incorrect results when attempting to split quoted strings.
