### PR TITLE
Refactor parse.split() to not need to put every special character manually

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -38,11 +38,24 @@ exports.parse = function(argv) {
 };
 
 exports.split = function(string) {
-  var result;
+  var pair, regex, result;
   if (string == null) {
     return [];
   }
-  result = string.match(/[\w-\*/\\:\.~]+|[<\['"][^<\[]+[>\]'"]/g) || [];
+  regex = '';
+  pair = function(_arg) {
+    var end, start;
+    start = _arg[0], end = _arg[1];
+    start = '\\' + start;
+    end = '\\' + end;
+    return regex += "" + start + "[^" + end + "]+" + end + "|";
+  };
+  pair('[]');
+  pair('<>');
+  pair('""');
+  pair("''");
+  regex += '\\S+';
+  result = string.match(new RegExp(regex, 'g')) || [];
   return _.map(result, function(word) {
     word = _.str.unquote(word, '\'');
     word = _.str.unquote(word, '"');

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -34,9 +34,23 @@ exports.parse = (argv) ->
 exports.split = (string) ->
 	return [] if not string?
 
-	# TODO: This regex should be vastly improved to avoid
-	# having to type all special characters manually
-	result = string.match(/[\w-\*/\\:\.~]+|[<\['"][^<\[]+[>\]'"]/g) or []
+	# TODO: Refactor this to use a manual lexer
+	regex = ''
+
+	pair = ([ start, end ]) ->
+		start = '\\' + start
+		end = '\\' + end
+		regex += "#{start}[^#{end}]+#{end}|"
+
+	pair('[]')
+	pair('<>')
+	pair('""')
+	pair("''")
+
+	regex += '\\S+'
+
+	result = string.match(new RegExp(regex, 'g')) or []
+
 	return _.map result, (word) ->
 		word = _.str.unquote(word, '\'')
 		word = _.str.unquote(word, '"')


### PR DESCRIPTION
More robust solution until a proper manual lexing implementation.
