### PR TITLE
Fix issue when parsing quoted multi word parameters #4

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -32,6 +32,12 @@ exports.parse = function(argv) {
   result.options = options;
   result.global = exports.parseOptions(state.globalOptions, options);
   if (!_.isEmpty(output._)) {
+    output._ = _.map(output._, function(word) {
+      if (/\s/.test(word)) {
+        word = _.str.quote(word);
+      }
+      return word;
+    });
     result.command = output._.join(' ');
   }
   return result;

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -27,6 +27,16 @@ exports.parse = (argv) ->
 	result.global = exports.parseOptions(state.globalOptions, options)
 
 	if not _.isEmpty(output._)
+
+		# Preserve quotes when joining the command.
+		# If a command word used to have quotes (e.g: had whitespace),
+		# we explicitly quote it back.
+		# https://github.com/resin-io/capitano/issues/4
+		output._ = _.map output._, (word) ->
+			if /\s/.test(word)
+				word = _.str.quote(word)
+			return word
+
 		result.command = output._.join(' ')
 
 	return result

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -147,6 +147,22 @@ describe 'Parse:', ->
 					global: {}
 					options: {}
 
+			it 'should not discard single quotes when parsing the command', ->
+				argv = parse.split('hello \'John Doe\'')
+				result = parse.parse(argv)
+				expect(result).to.deep.equal
+					command: 'hello "John Doe"'
+					global: {}
+					options: {}
+
+			it 'should not discard double quotes when parsing the command', ->
+				argv = parse.split('hello "John Doe"')
+				result = parse.parse(argv)
+				expect(result).to.deep.equal
+					command: 'hello "John Doe"'
+					global: {}
+					options: {}
+
 	describe '#split()', ->
 
 		it 'should return an empty array if no signature', ->


### PR DESCRIPTION
Fixes https://github.com/resin-io/capitano/issues/4.
