### PR TITLE
Fix issue with parsing words that start with a number

### DIFF
--- a/build/signature.js
+++ b/build/signature.js
@@ -82,7 +82,7 @@ module.exports = Signature = (function() {
   };
 
   Signature.prototype.compileParameters = function(command) {
-    var commandWords, comparison, item, parameter, parameterIndex, result, value, word, _i, _len;
+    var commandWords, comparison, item, parameter, parameterIndex, parameterValue, result, value, word, _i, _len;
     commandWords = parse.split(command);
     comparison = _.zip(this.parameters, commandWords);
     result = {};
@@ -96,11 +96,12 @@ module.exports = Signature = (function() {
       if (parameter == null) {
         throw new Error('Signature dismatch');
       }
+      parameterValue = parameter.getValue();
       if (!parameter.matches(word)) {
         if (parameter.isRequired()) {
-          throw new Error("Missing " + (parameter.getValue()));
+          throw new Error("Missing " + parameterValue);
         }
-        throw new Error("" + (parameter.getValue()) + " does not match " + word);
+        throw new Error("" + parameterValue + " does not match " + word);
       }
       if (parameter.isVariadic()) {
         parameterIndex = _.indexOf(this.parameters, parameter);
@@ -108,11 +109,15 @@ module.exports = Signature = (function() {
         if (parameter.isOptional() && _.isEmpty(value)) {
           return result;
         }
-        result[parameter.getValue()] = value;
+        result[parameterValue] = value;
         return result;
       }
       if (!parameter.isWord() && (word != null)) {
-        result[parameter.getValue()] = _.parseInt(word) || word;
+        if (/^\d+$/.test(word)) {
+          result[parameterValue] = _.parseInt(word);
+        } else {
+          result[parameterValue] = word;
+        }
       }
     }
     return result;

--- a/lib/signature.coffee
+++ b/lib/signature.coffee
@@ -80,11 +80,13 @@ module.exports = class Signature
 			if not parameter?
 				throw new Error('Signature dismatch')
 
+			parameterValue = parameter.getValue()
+
 			if not parameter.matches(word)
 				if parameter.isRequired()
-					throw new Error("Missing #{parameter.getValue()}")
+					throw new Error("Missing #{parameterValue}")
 
-				throw new Error("#{parameter.getValue()} does not match #{word}")
+				throw new Error("#{parameterValue} does not match #{word}")
 
 			if parameter.isVariadic()
 				parameterIndex = _.indexOf(@parameters, parameter)
@@ -93,10 +95,13 @@ module.exports = class Signature
 				if parameter.isOptional() and _.isEmpty(value)
 					return result
 
-				result[parameter.getValue()] = value
+				result[parameterValue] = value
 				return result
 
 			if not parameter.isWord() and word?
-				result[parameter.getValue()] = _.parseInt(word) or word
+				if /^\d+$/.test(word)
+					result[parameterValue] = _.parseInt(word)
+				else
+					result[parameterValue] = word
 
 		return result

--- a/tests/signature.spec.coffee
+++ b/tests/signature.spec.coffee
@@ -382,6 +382,11 @@ describe 'Signature:', ->
 				expect(result).to.deep.equal
 					bar: 19
 
+			it 'should match with a string that starts with a number', ->
+				signature = new Signature('<foo>')
+				result = signature.compileParameters('1bar')
+				expect(result).to.deep.equal(foo: '1bar')
+
 		describe 'given path commands', ->
 
 			it 'should be able to parse absolute paths', ->


### PR DESCRIPTION
If we tried to match a signature parameter with a word that started with a number (e.g: `1bar`), only the number would pass through. 