### PR TITLE
Catch action errors and send them to the callback automatically

### DIFF
--- a/build/command.js
+++ b/build/command.js
@@ -64,7 +64,12 @@ module.exports = Command = (function() {
         if (error != null) {
           return typeof callback === "function" ? callback(error) : void 0;
         }
-        _this.action(params, parsedOptions, callback);
+        try {
+          _this.action(params, parsedOptions, callback);
+        } catch (_error) {
+          error = _error;
+          return callback(error);
+        }
         if (_this.action.length < 3) {
           return typeof callback === "function" ? callback() : void 0;
         }

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -46,7 +46,11 @@ module.exports = class Command
 
 		@applyPermissions (error) =>
 			return callback?(error) if error?
-			@action(params, parsedOptions, callback)
+
+			try
+				@action(params, parsedOptions, callback)
+			catch error
+				return callback(error)
 
 			# Means the user is not declaring the callback
 			return callback?() if @action.length < 3

--- a/tests/command.spec.coffee
+++ b/tests/command.spec.coffee
@@ -366,6 +366,20 @@ describe 'Command:', ->
 			command.execute(command: 'foo bar')
 			expect(spy).to.have.been.calledOnce
 
+		describe 'given an action that throws an error', ->
+
+			beforeEach ->
+				@command = new Command
+					signature: new Signature('hello')
+					action: ->
+						throw new Error('Command Error')
+
+			it 'should catch the error and send it to the callback', (done) ->
+				@command.execute command: 'hello', (error) ->
+					expect(error).to.be.an.instanceof(Error)
+					expect(error.message).to.equal('Command Error')
+					done()
+
 		describe 'given a command with permissions', ->
 
 			beforeEach ->


### PR DESCRIPTION
Is not obvious that some sync call can throw an error. It happened to me often that I didn't wrap them in a `try/catch` clause, and thus the error bypassed my configured Capitano error handler mechanism.

By wrapping the command action call in a `try/catch` clause within Capitano, we can help the user not preventing such mistake, catching the error and passing it to the callback ourselves.