### PR TITLE
Implement stdin support. Closes #12.

### DIFF
--- a/build/capitano.js
+++ b/build/capitano.js
@@ -51,17 +51,20 @@ exports.permission = function(name, permissionFunction) {
 };
 
 exports.execute = function(args, callback) {
-  var command, error;
-  command = exports.state.getMatchCommand(args.command);
-  if (command == null) {
-    return exports.defaults.actions.commandNotFound(args.command);
-  }
-  try {
-    return command.execute(args, callback);
-  } catch (_error) {
-    error = _error;
-    return typeof callback === "function" ? callback(error) : void 0;
-  }
+  return exports.state.getMatchCommand(args.command, function(error, command) {
+    if (error != null) {
+      return typeof callback === "function" ? callback(error) : void 0;
+    }
+    if (command == null) {
+      return exports.defaults.actions.commandNotFound(args.command);
+    }
+    try {
+      return command.execute(args, callback);
+    } catch (_error) {
+      error = _error;
+      return typeof callback === "function" ? callback(error) : void 0;
+    }
+  });
 };
 
 exports.run = function(argv, callback) {

--- a/build/command.js
+++ b/build/command.js
@@ -53,26 +53,30 @@ module.exports = Command = (function() {
   };
 
   Command.prototype.execute = function(args, callback) {
-    var params, parsedOptions;
     if (args == null) {
       args = {};
     }
-    params = this.signature.compileParameters(args.command);
-    parsedOptions = this._parseOptions(args.options);
-    return this.applyPermissions((function(_this) {
-      return function(error) {
+    return this.signature.compileParameters(args.command, (function(_this) {
+      return function(error, params) {
+        var parsedOptions;
         if (error != null) {
           return typeof callback === "function" ? callback(error) : void 0;
         }
-        try {
-          _this.action(params, parsedOptions, callback);
-        } catch (_error) {
-          error = _error;
-          return callback(error);
-        }
-        if (_this.action.length < 3) {
-          return typeof callback === "function" ? callback() : void 0;
-        }
+        parsedOptions = _this._parseOptions(args.options);
+        return _this.applyPermissions(function(error) {
+          if (error != null) {
+            return typeof callback === "function" ? callback(error) : void 0;
+          }
+          try {
+            _this.action(params, parsedOptions, callback);
+          } catch (_error) {
+            error = _error;
+            return typeof callback === "function" ? callback(error) : void 0;
+          }
+          if (_this.action.length < 3) {
+            return typeof callback === "function" ? callback() : void 0;
+          }
+        });
       };
     })(this));
   };

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,0 +1,5 @@
+var stdin;
+
+stdin = require('get-stdin');
+
+exports.getStdin = stdin;

--- a/lib/capitano.coffee
+++ b/lib/capitano.coffee
@@ -43,15 +43,16 @@ exports.permission = (name, permissionFunction) ->
 	exports.state.permissions[name] = permissionFunction
 
 exports.execute = (args, callback) ->
-	command = exports.state.getMatchCommand(args.command)
+	exports.state.getMatchCommand args.command, (error, command) ->
+		return callback?(error) if error?
 
-	if not command?
-		return exports.defaults.actions.commandNotFound(args.command)
+		if not command?
+			return exports.defaults.actions.commandNotFound(args.command)
 
-	try
-		command.execute(args, callback)
-	catch error
-		return callback?(error)
+		try
+			command.execute(args, callback)
+		catch error
+			return callback?(error)
 
 # Handy shortcut
 exports.run = (argv, callback) ->

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -41,19 +41,21 @@ module.exports = class Command
 		parsedOptions = parse.parseOptions(allOptions, options)
 
 	execute: (args = {}, callback) ->
-		params = @signature.compileParameters(args.command)
-		parsedOptions = @_parseOptions(args.options)
-
-		@applyPermissions (error) =>
+		@signature.compileParameters args.command, (error, params) =>
 			return callback?(error) if error?
 
-			try
-				@action(params, parsedOptions, callback)
-			catch error
-				return callback(error)
+			parsedOptions = @_parseOptions(args.options)
 
-			# Means the user is not declaring the callback
-			return callback?() if @action.length < 3
+			@applyPermissions (error) =>
+				return callback?(error) if error?
+
+				try
+					@action(params, parsedOptions, callback)
+				catch error
+					return callback?(error)
+
+				# Means the user is not declaring the callback
+				return callback?() if @action.length < 3
 
 	option: (option) ->
 		if option not instanceof Option

--- a/lib/parameter.coffee
+++ b/lib/parameter.coffee
@@ -6,6 +6,8 @@ REGEX_REQUIRED = /^<(.*)>$/
 REGEX_OPTIONAL = /^\[(.*)\]$/
 REGEX_VARIADIC = /^[<\[](.*)[\.]{3}[>\]]$/
 REGEX_MULTIWORD = /\s/
+REGEX_STDIN = /^[<\[]\|(.*)[\]>]$/
+STDIN_CHARACTER = '|'
 
 module.exports = class Parameter
 	constructor: (parameter) ->
@@ -17,6 +19,9 @@ module.exports = class Parameter
 			throw new Error("Missing or invalid parameter: #{parameter}")
 
 		@parameter = parameter
+
+		if @isVariadic() and @allowsStdin()
+			throw new Error('Parameter can\'t be variadic and allow stdin')
 
 	_testRegex: (regex) ->
 		return regex.test(@parameter)
@@ -39,11 +44,15 @@ module.exports = class Parameter
 	isMultiWord: ->
 		return @_testRegex(REGEX_MULTIWORD)
 
+	allowsStdin: ->
+		return @parameter[1] is STDIN_CHARACTER
+
 	getValue: ->
 		return @parameter if @isWord()
 		regex = REGEX_REQUIRED if @isRequired()
 		regex = REGEX_OPTIONAL if @isOptional()
 		regex = REGEX_VARIADIC if @isVariadic()
+		regex = REGEX_STDIN if @allowsStdin()
 		result = @parameter.match(regex)
 		return result[1]
 

--- a/lib/state.coffee
+++ b/lib/state.coffee
@@ -1,4 +1,5 @@
 _ = require('lodash')
+async = require('async')
 settings = require('./settings')
 
 exports.commands = []
@@ -9,15 +10,19 @@ exports.findCommandBySignature = (signature) ->
 	return _.findWhere exports.commands, (command) ->
 		return command.signature.toString() is signature
 
-exports.getMatchCommand = (signature) ->
+exports.getMatchCommand = (signature, callback) ->
 
-	for command in exports.commands
+	# Omit wildcard command from the check
+	commands = _.reject exports.commands, (command) ->
+		return command.isWildcard()
 
-		# Omit wildcard command from the check
-		continue if command.isWildcard()
+	async.eachSeries commands, (command, done) ->
+		command.signature.matches signature, (result) ->
+			return done() if not result
+			return callback(null, command)
+	, (error) ->
+		return callback(error) if error?
 
-		if command.signature.matches(signature)
-			return command
-
-	wildcardSignature = settings.signatures.wildcard
-	return exports.findCommandBySignature(wildcardSignature)
+		wildcardSignature = settings.signatures.wildcard
+		result = exports.findCommandBySignature(wildcardSignature)
+		return callback(null, result)

--- a/lib/state.coffee
+++ b/lib/state.coffee
@@ -19,6 +19,13 @@ exports.getMatchCommand = (signature, callback) ->
 	async.eachSeries commands, (command, done) ->
 		command.signature.matches signature, (result) ->
 			return done() if not result
+
+			# TODO: Breaking from the async look this way may
+			# cause a memory leak.
+			# One possible solution is to call done() with the result
+			# tricking async that is an error, and handle accordingly
+			# in the final callback. However the solution looks ugly.
+			# Search for alternatives
 			return callback(null, command)
 	, (error) ->
 		return callback(error) if error?

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,0 +1,4 @@
+stdin = require('get-stdin')
+
+# Wrap stdin in order to being able to mock it with Sinon.
+exports.getStdin = stdin

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
+    "async": "^0.9.0",
+    "get-stdin": "^4.0.1",
     "lodash": "~2.4.1",
-    "underscore.string": "~2.4.0",
-    "minimist": "~1.1.0"
+    "minimist": "~1.1.0",
+    "underscore.string": "~2.4.0"
   }
 }

--- a/tests/capitano.spec.coffee
+++ b/tests/capitano.spec.coffee
@@ -1,8 +1,10 @@
 _ = require('lodash')
 sinon = require('sinon')
 chai = require('chai')
+chai.use(require('sinon-chai'))
 expect = chai.expect
 cliManager = require('../lib/capitano')
+utils = require('../lib/utils')
 
 describe 'Capitano:', ->
 
@@ -173,6 +175,44 @@ describe 'Capitano:', ->
 			expect ->
 				cliManager.execute(command: 'hello')
 			.to.not.throw(Error)
+
+		describe 'given a stdin command', ->
+
+			describe 'if parameter was passed', ->
+
+				it 'should execute correctly', ->
+					spy = sinon.spy()
+
+					cliManager.command
+						signature: 'hello <|name>'
+						action: spy
+
+					cliManager.execute(command: 'hello John')
+
+					expect(spy).to.have.been.calledOnce
+					expect(spy).to.have.been.calledWith(name: 'John')
+
+			describe 'if stdin was passed', ->
+
+				beforeEach ->
+					@utilsGetStdinStub = sinon.stub(utils, 'getStdin')
+					@utilsGetStdinStub.callsArgWithAsync(0, 'Jane')
+
+				afterEach ->
+					@utilsGetStdinStub.restore()
+
+				it 'should execute correctly', (done) ->
+					spy = sinon.spy()
+
+					cliManager.command
+						signature: 'hello <|name>'
+						action: spy
+
+					cliManager.execute command: 'hello', (error) ->
+						expect(error).to.not.exist
+						expect(spy).to.have.been.calledOnce
+						expect(spy).to.have.been.calledWith(name: 'Jane')
+						done()
 
 	describe '#run()', ->
 

--- a/tests/parameter.spec.coffee
+++ b/tests/parameter.spec.coffee
@@ -21,6 +21,16 @@ describe 'Parameter:', ->
 				new Parameter([ 1, 2, 3 ])
 			.to.throw(Error)
 
+		it 'should return an error if required variadic and has stdin support', ->
+			expect ->
+				new Parameter('<|foo...>')
+			.to.throw('Parameter can\'t be variadic and allow stdin')
+
+		it 'should return an error if optional variadic and has stdin support', ->
+			expect ->
+				new Parameter('[|foo...]')
+			.to.throw('Parameter can\'t be variadic and allow stdin')
+
 	describe '#isRequired()', ->
 
 		it 'should return true for required parameters', ->
@@ -203,6 +213,58 @@ describe 'Parameter:', ->
 			parameter = new Parameter('[foo...]')
 			expect(parameter.isMultiWord()).to.be.false
 
+	describe '#allowsStdin()', ->
+
+		it 'should return false for required parameters', ->
+			parameter = new Parameter('<foo>')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return false for variadic required parameters', ->
+			parameter = new Parameter('<foo...>')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return false for multi word required parameters', ->
+			parameter = new Parameter('<foo bar>')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return false for optional parameters', ->
+			parameter = new Parameter('[foo]')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return false for variadic optional parameters', ->
+			parameter = new Parameter('[foo...]')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return false for invalid parameters', ->
+			for input in [
+				'foo'
+				'<foo]'
+				'[foo>'
+				''
+			]
+				parameter = new Parameter(input)
+				expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return true if required with |', ->
+			parameter = new Parameter('<|foo>')
+			expect(parameter.allowsStdin()).to.be.true
+
+		it 'should return true if optional with |', ->
+			parameter = new Parameter('[|foo]')
+			expect(parameter.allowsStdin()).to.be.true
+
+		it 'should return false if no parameter with |', ->
+			parameter = new Parameter('|foo')
+			expect(parameter.allowsStdin()).to.be.false
+
+		it 'should return true if multi word required with |', ->
+			parameter = new Parameter('<|foo bar>')
+			expect(parameter.allowsStdin()).to.be.true
+
+		it 'should return true if multi word optional with |', ->
+			parameter = new Parameter('[|foo bar]')
+			expect(parameter.allowsStdin()).to.be.true
+
 	describe '#getValue()', ->
 
 		it 'should get word values', ->
@@ -235,6 +297,14 @@ describe 'Parameter:', ->
 
 		it 'should get the value of variadic optional parameter', ->
 			parameter = new Parameter('[foo...]')
+			expect(parameter.getValue()).to.equal('foo')
+
+		it 'should get the value of stdin optional parameter', ->
+			parameter = new Parameter('[|foo]')
+			expect(parameter.getValue()).to.equal('foo')
+
+		it 'should get the value of stdin required parameter', ->
+			parameter = new Parameter('<|foo>')
 			expect(parameter.getValue()).to.equal('foo')
 
 	describe '#getType()', ->

--- a/tests/state.spec.coffee
+++ b/tests/state.spec.coffee
@@ -29,23 +29,53 @@ describe 'State:', ->
 			state.commands = []
 			state.commands.push(@command)
 
-		it 'should return the command', ->
-			result = state.getMatchCommand('foo hello')
-			expect(result).to.deep.equal(@command)
+		it 'should return the command', (done) ->
+			state.getMatchCommand 'foo hello', (error, result) =>
+				expect(error).to.not.exist
+				expect(result).to.deep.equal(@command)
+				done()
 
-		it 'should return undefined if no match', ->
-			result = state.getMatchCommand('bar baz foo')
-			expect(result).to.be.undefined
+		it 'should return undefined if no match', (done) ->
+			state.getMatchCommand 'bar baz foo', (error, result) ->
+				expect(error).to.not.exist
+				expect(result).to.be.undefined
+				done()
 
-		it 'should match variadic arguments', ->
+		it 'should match variadic arguments', (done) ->
 			state.commands = []
 			command = new Command
 				signature: new Signature('help [command...]')
 				action: _.noop
 			state.commands.push(command)
 
-			result = state.getMatchCommand('help foo bar')
-			expect(result).to.deep.equal(command)
+			state.getMatchCommand 'help foo bar', (error, result) ->
+				expect(error).to.not.exist
+				expect(result).to.deep.equal(command)
+				done()
+
+		it 'should match required stdin arguments', (done) ->
+			state.commands = []
+			command = new Command
+				signature: new Signature('foo <|bar>')
+				action: _.noop
+			state.commands.push(command)
+
+			state.getMatchCommand 'foo', (error, result) ->
+				expect(error).to.not.exist
+				expect(result).to.deep.equal(command)
+				done()
+
+		it 'should match optional stdin arguments', (done) ->
+			state.commands = []
+			command = new Command
+				signature: new Signature('foo [|bar]')
+				action: _.noop
+			state.commands.push(command)
+
+			state.getMatchCommand 'foo', (error, result) ->
+				expect(error).to.not.exist
+				expect(result).to.deep.equal(command)
+				done()
 
 		describe 'if wildcard command is defined', ->
 
@@ -56,9 +86,11 @@ describe 'State:', ->
 
 				state.commands.push(@wilcardCommand)
 
-			it 'should return that command if no match', ->
-				command = state.getMatchCommand('not defined command')
-				expect(command).to.deep.equal(@wilcardCommand)
+			it 'should return that command if no match', (done) ->
+				state.getMatchCommand 'not defined command', (error, result) =>
+					expect(error).to.not.exist
+					expect(result).to.deep.equal(@wilcardCommand)
+					done()
 
 	describe '#findCommandBySignature()', ->
 


### PR DESCRIPTION
Implements stdin support with the following syntax: `<|foo>` or `[|foo]`.

There can only be one stdin parameter, and it has to be the last parameter of the signature (otherwise errors are thrown reporting wrong usage).

Also, this is a slightly breaking change as `state.getMatchCommand()` is now async (due to stdin read being async). Documented accordingly in the README.
