### PR TITLE
Fix unit tests race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"

--- a/tests/capitano.spec.coffee
+++ b/tests/capitano.spec.coffee
@@ -108,17 +108,18 @@ describe 'Capitano:', ->
 
 	describe '#execute()', ->
 
-		it 'should execute a command', ->
+		it 'should execute a command', (done) ->
 			spy = sinon.spy()
 
 			cliManager.command
 				signature: 'hello <name>'
 				action: spy
 
-			cliManager.execute(command: 'hello John')
-
-			expect(spy).to.have.been.calledOnce
-			expect(spy).to.have.been.calledWith(name: 'John')
+			cliManager.execute command: 'hello John', (error) ->
+				expect(error).to.not.exist
+				expect(spy).to.have.been.calledOnce
+				expect(spy).to.have.been.calledWith(name: 'John')
+				done()
 
 		it 'should call commandNotFound if command not found', ->
 			commandNotFoundStub = sinon.stub(cliManager.defaults.actions, 'commandNotFound')
@@ -180,17 +181,18 @@ describe 'Capitano:', ->
 
 			describe 'if parameter was passed', ->
 
-				it 'should execute correctly', ->
+				it 'should execute correctly', (done) ->
 					spy = sinon.spy()
 
 					cliManager.command
 						signature: 'hello <|name>'
 						action: spy
 
-					cliManager.execute(command: 'hello John')
-
-					expect(spy).to.have.been.calledOnce
-					expect(spy).to.have.been.calledWith(name: 'John')
+					cliManager.execute command: 'hello John', (error) ->
+						expect(error).to.not.exist
+						expect(spy).to.have.been.calledOnce
+						expect(spy).to.have.been.calledWith(name: 'John')
+						done()
 
 			describe 'if stdin was passed', ->
 
@@ -216,16 +218,18 @@ describe 'Capitano:', ->
 
 	describe '#run()', ->
 
-		it 'should parse and execute a command', ->
+		it 'should parse and execute a command', (done) ->
 			spy = sinon.spy()
 
 			cliManager.command
 				signature: 'hello <name>'
 				action: spy
 
-			cliManager.run('hello John')
-			expect(spy).to.have.been.calledOnce
-			expect(spy).to.have.been.calledWith(name: 'John')
+			cliManager.run 'hello John', (error) ->
+				expect(error).to.not.exist
+				expect(spy).to.have.been.calledOnce
+				expect(spy).to.have.been.calledWith(name: 'John')
+				done()
 
 		it 'should pass any error to the callback', (done) ->
 			cliManager.command

--- a/tests/command.spec.coffee
+++ b/tests/command.spec.coffee
@@ -332,40 +332,40 @@ describe 'Command:', ->
 				}
 				done()
 
-		it 'should be able to call the done callback manually', ->
-			spy = sinon.spy()
+		it 'should be able to call the done callback manually', (done) ->
+			command = new Command
+				signature: new Signature('foo <bar>')
+				action: (params, options, callback) ->
+					return callback(null, 123)
+
+			command.execute command: 'foo bar', (error, data) ->
+				expect(error).to.not.exist
+				expect(data).to.equal(123)
+				done()
+
+		it 'should be able to call the done callback with an error', (done) ->
+			cliError = new Error('Test error')
 
 			command = new Command
 				signature: new Signature('foo <bar>')
 				action: (params, options, callback) ->
-					return callback()
+					return callback(cliError)
 
-			command.execute(command: 'foo bar', spy)
+			command.execute command: 'foo bar', (error) ->
+				expect(error).to.deep.equal(cliError)
+				done()
 
-			expect(spy).to.have.been.calledOnce
-
-		it 'should be able to call the done callback with an error', ->
-			spy = sinon.spy()
-			error = new Error('Test error')
-
-			command = new Command
-				signature: new Signature('foo <bar>')
-				action: (params, options, callback) ->
-					return callback(error)
-
-			command.execute(command: 'foo bar', spy)
-
-			expect(spy).to.have.been.calledWithExactly(error)
-
-		it 'should call the action if no callback', ->
+		it 'should call the action if no callback', (done) ->
 			spy = sinon.spy()
 
 			command = new Command
 				signature: new Signature('foo <bar>')
 				action: spy
 
-			command.execute(command: 'foo bar')
-			expect(spy).to.have.been.calledOnce
+			command.execute command: 'foo bar', (error) ->
+				expect(error).to.not.exist
+				expect(spy).to.have.been.calledOnce
+				done()
 
 		describe 'given an action that throws an error', ->
 


### PR DESCRIPTION
There was a race condition between the commands executing the action and
out action spy assertions. We now make sure the execute function completed
before checking the spy.

This also has the nice consequence of forcing us to test the error objects
in the callbacks, as previously an error would have been ignored.