### PR TITLE
Fix option values starting with numbers from being parsed as numbers

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -90,7 +90,10 @@ exports.parseOptions = function(definedOptions, options) {
     if (!definedOption.matches(value)) {
       continue;
     }
-    result[signature] = _.parseInt(value) || value;
+    if (/^\d+$/.test(value)) {
+      value = _.parseInt(value);
+    }
+    result[signature] = value;
   }
   return result;
 };

--- a/build/state.js
+++ b/build/state.js
@@ -13,7 +13,7 @@ exports.globalOptions = [];
 exports.permissions = {};
 
 exports.findCommandBySignature = function(signature) {
-  return _.findWhere(exports.commands, function(command) {
+  return _.find(exports.commands, function(command) {
     return command.signature.toString() === signature;
   });
 };

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -76,6 +76,10 @@ exports.parseOptions = (definedOptions, options = {}) ->
 				throw new Error("Option #{definedOption.signature} is required")
 
 		continue if not definedOption.matches(value)
-		result[signature] = _.parseInt(value) or value
+
+		if /^\d+$/.test(value)
+			value = _.parseInt(value)
+
+		result[signature] = value
 
 	return result

--- a/tests/capitano.spec.coffee
+++ b/tests/capitano.spec.coffee
@@ -231,6 +231,23 @@ describe 'Capitano:', ->
 				expect(spy).to.have.been.calledWith(name: 'John')
 				done()
 
+		it 'should pass an option value starting with a number correctly', (done) ->
+			spy = sinon.spy()
+
+			cliManager.command
+				signature: 'hello'
+				action: spy
+				options: [
+					signature: 'application'
+					parameter: 'application'
+				]
+
+			cliManager.run 'hello --application 10Jun2014', (error) ->
+				expect(error).to.not.exist
+				expect(spy).to.have.been.calledOnce
+				expect(spy).to.have.been.calledWith({}, application: '10Jun2014')
+				done()
+
 		it 'should pass any error to the callback', (done) ->
 			cliManager.command
 				signature: 'hello <name>'

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -290,6 +290,32 @@ describe 'Parse:', ->
 				foo: 'baz'
 				quiet: true
 
+		it 'should parse options starting with a number correctly', ->
+			definedOptions = []
+			definedOptions.push new Option
+				signature: new Signature('foo')
+				parameter: 'bar'
+
+			options =
+				foo: '10foobar'
+
+			result = parse.parseOptions(definedOptions, options)
+			expect(result).to.deep.equal
+				foo: '10foobar'
+
+		it 'should parse options containing integers as numbers', ->
+			definedOptions = []
+			definedOptions.push new Option
+				signature: new Signature('foo')
+				parameter: 'bar'
+
+			options =
+				foo: '10'
+
+			result = parse.parseOptions(definedOptions, options)
+			expect(result).to.deep.equal
+				foo: 10
+
 		it 'should discard non matched options', ->
 			definedOptions = []
 			definedOptions.push new Option


### PR DESCRIPTION
For example:

	$ myapp --foo 10bar

In that case `foo` was equal to `10`, instead of `10bar`.