### PR TITLE
Add EACCES code to the error thrown on "root" commands

### DIFF
--- a/build/command.js
+++ b/build/command.js
@@ -77,7 +77,9 @@ module.exports = Command = (function() {
             return typeof callback === "function" ? callback(error) : void 0;
           }
           if (_this.root && !isElevated) {
-            return callback(new Error('You need admin privileges to run this command'));
+            error = new Error('You need admin privileges to run this command');
+            error.code = 'EACCES';
+            return callback(error);
           }
           parsedOptions = _this._parseOptions(args.options);
           return _this.applyPermissions(function(error) {

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -56,7 +56,9 @@ module.exports = class Command
 				return callback?(error) if error?
 
 				if @root and not isElevated
-					return callback(new Error('You need admin privileges to run this command'))
+					error = new Error('You need admin privileges to run this command')
+					error.code = 'EACCES'
+					return callback(error)
 
 				parsedOptions = @_parseOptions(args.options)
 

--- a/tests/command.spec.coffee
+++ b/tests/command.spec.coffee
@@ -423,6 +423,7 @@ describe 'Command:', ->
 					@command.execute command: 'foo', (error) ->
 						expect(error).to.be.an.instanceof(Error)
 						expect(error.message).to.equal('You need admin privileges to run this command')
+						expect(error.code).to.equal('EACCES')
 						done()
 
 		describe 'given a command with permissions', ->


### PR DESCRIPTION
This helps clients understand the reason of the error, and potentially modify the error message contents.