### PR TITLE
Pass missing required option error to callback

### DIFF
--- a/build/command.js
+++ b/build/command.js
@@ -81,7 +81,12 @@ module.exports = Command = (function() {
             error.code = 'EACCES';
             return callback(error);
           }
-          parsedOptions = _this._parseOptions(args.options);
+          try {
+            parsedOptions = _this._parseOptions(args.options);
+          } catch (_error) {
+            error = _error;
+            return typeof callback === "function" ? callback(error) : void 0;
+          }
           return _this.applyPermissions(function(error) {
             if (error != null) {
               return typeof callback === "function" ? callback(error) : void 0;

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -60,7 +60,10 @@ module.exports = class Command
 					error.code = 'EACCES'
 					return callback(error)
 
-				parsedOptions = @_parseOptions(args.options)
+				try
+					parsedOptions = @_parseOptions(args.options)
+				catch error
+					return callback?(error)
 
 				@applyPermissions (error) =>
 					return callback?(error) if error?

--- a/tests/command.spec.coffee
+++ b/tests/command.spec.coffee
@@ -270,6 +270,24 @@ describe 'Command:', ->
 				}
 				done()
 
+		it 'should return an error if lacking a required option', (done) ->
+			command = new Command
+				signature: new Signature('foo <bar>')
+				action: _.noop
+				options: [
+					new Option
+						signature: new Signature('quiet')
+						boolean: true
+						required: 'You have to pass this option'
+				]
+
+			command.execute {
+				command: 'foo baz'
+			}, (error) ->
+				expect(error).to.be.an.instanceof(Error)
+				expect(error.message).to.equal('You have to pass this option')
+				done()
+
 		it 'should parse global and command options', (done) ->
 			spy = sinon.spy()
 


### PR DESCRIPTION
Currently the error is thrown synchronously evading the error handling
code setup by the client.