### PR TITLE
Replace minimist with yargs-parser

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -1,10 +1,10 @@
-var Parameter, _, minimist, settings, state;
+var Parameter, _, settings, state, yargsParser;
 
 _ = require('lodash');
 
 _.str = require('underscore.string');
 
-minimist = require('minimist');
+yargsParser = require('yargs-parser');
 
 settings = require('./settings');
 
@@ -28,7 +28,7 @@ exports.normalizeInput = function(argv) {
 exports.parse = function(argv) {
   var options, output, result;
   argv = exports.normalizeInput(argv);
-  output = minimist(argv);
+  output = yargsParser(argv);
   options = _.omit(output, '_');
   result = {};
   result.options = options;

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -1,6 +1,6 @@
 _ = require('lodash')
 _.str = require('underscore.string')
-minimist = require('minimist')
+yargsParser = require('yargs-parser')
 settings = require('./settings')
 state = require('./state')
 Parameter = require('./parameter')
@@ -18,7 +18,7 @@ exports.normalizeInput = (argv) ->
 
 exports.parse = (argv) ->
 	argv = exports.normalizeInput(argv)
-	output = minimist(argv)
+	output = yargsParser(argv)
 
 	options = _.omit(output, '_')
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "get-stdin": "^4.0.1",
     "is-elevated": "^1.0.0",
     "lodash": "~3.9.1",
-    "minimist": "~1.1.1",
-    "underscore.string": "~3.0.3"
+    "underscore.string": "~3.0.3",
+    "yargs-parser": "^2.4.0"
   }
 }


### PR DESCRIPTION
The latter is a drop-in replacement since minimist has been deprecated
and its no longer mantained

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>