### PR TITLE
Don't evaluate numbers in scientific notation automatically

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,5 @@
 coffee_script:
   config_file: coffeelint.json
 
-java_script:
+javascript:
   enabled: false

--- a/build/capitano.js
+++ b/build/capitano.js
@@ -54,6 +54,7 @@ exports.permission = function(name, permissionFunction) {
 
 exports.execute = function(args, callback) {
   return exports.state.getMatchCommand(args.command, function(error, command) {
+    var error1;
     if (error != null) {
       return typeof callback === "function" ? callback(error) : void 0;
     }
@@ -62,8 +63,8 @@ exports.execute = function(args, callback) {
     }
     try {
       return command.execute(args, callback);
-    } catch (_error) {
-      error = _error;
+    } catch (error1) {
+      error = error1;
       return typeof callback === "function" ? callback(error) : void 0;
     }
   });

--- a/build/command.js
+++ b/build/command.js
@@ -72,7 +72,7 @@ module.exports = Command = (function() {
           return typeof callback === "function" ? callback(error) : void 0;
         }
         return _this._checkElevation(function(error, isElevated) {
-          var parsedOptions;
+          var error1, parsedOptions;
           if (error != null) {
             return typeof callback === "function" ? callback(error) : void 0;
           }
@@ -83,18 +83,19 @@ module.exports = Command = (function() {
           }
           try {
             parsedOptions = _this._parseOptions(args.options);
-          } catch (_error) {
-            error = _error;
+          } catch (error1) {
+            error = error1;
             return typeof callback === "function" ? callback(error) : void 0;
           }
           return _this.applyPermissions(function(error) {
+            var error2;
             if (error != null) {
               return typeof callback === "function" ? callback(error) : void 0;
             }
             try {
               _this.action(params, parsedOptions, callback);
-            } catch (_error) {
-              error = _error;
+            } catch (error2) {
+              error = error2;
               return typeof callback === "function" ? callback(error) : void 0;
             }
             if (_this.action.length < 3) {

--- a/build/parse.js
+++ b/build/parse.js
@@ -28,10 +28,19 @@ exports.normalizeInput = function(argv) {
 exports.parse = function(argv) {
   var options, output, result;
   argv = exports.normalizeInput(argv);
-  output = yargsParser(argv);
+  output = yargsParser(argv, {
+    configuration: {
+      'parse-numbers': false
+    }
+  });
   options = _.omit(output, '_');
   result = {};
-  result.options = options;
+  result.options = _.mapValues(options, function(value) {
+    if (/^[\d\.]+$/.test(value)) {
+      return parseFloat(value);
+    }
+    return value;
+  });
   result.global = exports.parseOptions(state.globalOptions, options);
   if (!_.isEmpty(output._)) {
     output._ = _.map(output._, function(word) {

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -18,13 +18,19 @@ exports.normalizeInput = (argv) ->
 
 exports.parse = (argv) ->
 	argv = exports.normalizeInput(argv)
-	output = yargsParser(argv)
+	output = yargsParser argv,
+		configuration:
+			'parse-numbers': false
 
 	options = _.omit(output, '_')
 
 	result = {}
 
-	result.options = options
+	result.options = _.mapValues options, (value) ->
+		if /^[\d\.]+$/.test(value)
+			return parseFloat(value)
+		return value
+
 	result.global = exports.parseOptions(state.globalOptions, options)
 
 	if not _.isEmpty(output._)

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -179,6 +179,24 @@ describe 'Parse:', ->
 					global: {}
 					options: {}
 
+			it 'should not parse numbers in scientific notation automatically', ->
+				argv = parse.split('hello -x 43e8273')
+				result = parse.parse(argv)
+				expect(result).to.deep.equal
+					command: 'hello'
+					global: {}
+					options:
+						x: '43e8273'
+
+			it 'should parse float numbers automatically', ->
+				argv = parse.split('hello -x 1.5')
+				result = parse.parse(argv)
+				expect(result).to.deep.equal
+					command: 'hello'
+					global: {}
+					options:
+						x: 1.5
+
 	describe '#split()', ->
 
 		it 'should return an empty array if no signature', ->


### PR DESCRIPTION
This leads to all sort of confusing errors when passing UUIDs as arguments.

For example: `43e8273` is incorrectly considered as a huge number in
scientific notation that gets evaluated as `Infinity`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>